### PR TITLE
Fixed bug when multiple roles are in present in identity claims

### DIFF
--- a/src/AppText/Features/User/User.cs
+++ b/src/AppText/Features/User/User.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Security.Claims;
 
 namespace AppText.Features.User
 {
@@ -6,6 +7,6 @@ namespace AppText.Features.User
     {
         public string Identifier { get; set; }
         public string Name { get; set; }
-        public IDictionary<string, string> Claims { get; set; }
+        public IEnumerable<Claim> Claims { get; set; }
     }
 }

--- a/src/AppText/Features/User/UserController.cs
+++ b/src/AppText/Features/User/UserController.cs
@@ -12,19 +12,12 @@ namespace AppText.Features.User
         public IActionResult GetCurrentUser()
         {
             var user = new User();
-            if (this.User.Identity.IsAuthenticated)
             {
-                user.Identifier = this.User.FindFirstValue("sub") ?? this.User.FindFirstValue(ClaimTypes.NameIdentifier);
-                user.Name = this.User.Identity.Name;
+                user.Identifier = this.User.Identity.IsAuthenticated ? this.User.FindFirstValue("sub") ?? this.User.FindFirstValue(ClaimTypes.NameIdentifier) : null;
+                user.Name = this.User.Identity.IsAuthenticated ? user.Name = this.User.Identity.Name : "Anonymous";
+                user.Claims = this.User.Claims;
             }
-            else
-            {
-                user.Name = "Anonymous";
-            }
-            user.Name = this.User.Identity.IsAuthenticated
-                ? user.Name = this.User.Identity.Name
-                : "Anonymous";
-            user.Claims = this.User.Claims.ToDictionary(c => c.Type, c => c.Value);
+            
             return Ok(user);
         }
     }


### PR DESCRIPTION
Replaced the dictionary used for claims by an IEnumerable<Claim> type to avoid unique key conflicts. Also refactored the UserController to avoid double setting the Identity Name.